### PR TITLE
Adds karma with jasmine for testing

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,36 @@
+var webpackConfig = require('./webpack.config.js')
+
+module.exports = function(config) {
+  config.set({
+    browsers: ['PhantomJS', 'Chrome'],
+    frameworks: ['jasmine'],
+
+    basePath: 'test',
+    autoWatch: false,
+    files: ['webpack-loader.js'],
+    preprocessors: {
+      'webpack-loader.js': ['webpack'],
+    },
+
+    plugins: [
+      require("karma-webpack"),
+      'karma-jasmine',
+      'karma-phantomjs-launcher',
+    ],
+
+    webpack: webpackConfig,
+
+    client: {
+      caputreConsole: true
+    },
+
+    reporters: ['dots'],
+    singleRun: true,
+
+    webpackMiddleware: {
+      noInfo: true
+    },
+
+    browserNoActivityTimeout: 60000,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -38,5 +38,14 @@
     "url-loader": "^0.5.6",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.0"
+  },
+  "devDependencies": {
+    "jasmine": "^2.3.2",
+    "jasmine-core": "^2.3.4",
+    "karma": "^0.13.14",
+    "karma-jasmine": "^0.3.6",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-webpack": "^1.7.0",
+    "phantomjs": "^1.9.18"
   }
 }

--- a/test.webpack.js
+++ b/test.webpack.js
@@ -1,0 +1,3 @@
+console.log("fuckyeah");
+var context = require.context('./test', true, /-test\.js$/);
+context.keys().forEach(context);

--- a/test/spec_test.js
+++ b/test/spec_test.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import React from 'react'
+import TestUtils from 'react/lib/ReactTestUtils'
+
+describe('A spec', function() {
+  it('fuggin works', function() {
+    expect(true).toBe(true);
+  });
+});

--- a/test/webpack-loader.js
+++ b/test/webpack-loader.js
@@ -1,0 +1,6 @@
+// phantomjs doesn't have es5
+(Function.prototype.bind)
+require('babel-core/polyfill');
+
+var context = require.context('.', true, /_test\.js$/);
+context.keys().forEach(context)


### PR DESCRIPTION
## Why?

We need testing infrastructure in place so we can roll with TDD moving forward.

## What Changed?

- Added karma, jasmine, phantomJS and supporting libraries
- Integrated karma with webPack build so that tests will have app code available to them
- Created a barebones test for ensuring the test env works
- Configured Karma to run all tests ending in `_test.js` in `./tests`