### PR TITLE
[STABLE] Silence JQuery errors by exporting global $

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,9 @@ import { ReduxRouter } from 'redux-router';
 import configureStore from './configureStore';
 import { loadFromCdn } from './load_from_cdn';
 
-const store = configureStore();
+// Bootstrap.js doesn't use ES6 modules yet. Need to globally export.
+// Know a more ES6 compliant way to do this? Submit a PR!
+require("exports?$!jquery");
 
 require("!style!css!sass!./css/alerts.scss");
 require("!style!css!sass!./css/blocks.scss");
@@ -35,11 +37,10 @@ loadFromCdn(
   "//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css",
   "css");
 loadFromCdn(
-  "//code.jquery.com/jquery-2.1.4.min.js",
-  "js");
-loadFromCdn(
   "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js",
   "js");
+
+const store = configureStore();
 
 class Root extends Component {
   render() {
@@ -57,4 +58,3 @@ class Root extends Component {
 }
 
 ReactDOM.render(<Root/>, document.getElementById('root'));
-

--- a/src/routes/dashboard/farm_designer/group_inventory.js
+++ b/src/routes/dashboard/farm_designer/group_inventory.js
@@ -29,7 +29,7 @@ export class Groups extends React.Component {
           </div>
         </div>
         <div className="search-box-wrapper">
-          <i class="fa fa-search"></i>
+          <i className="fa fa-search"></i>
           <input className="search" placeholder="Search"/>
           <div className="search-underline"></div>
         </div>

--- a/src/routes/dashboard/farm_designer/plant_inventory.js
+++ b/src/routes/dashboard/farm_designer/plant_inventory.js
@@ -30,7 +30,7 @@ export class Plants extends React.Component {
           </div>
         </div>
         <div className="search-box-wrapper">
-          <i class="fa fa-search"></i>
+          <i className="fa fa-search"></i>
           <input className="search" placeholder="Search"/>
           <div className="search-underline"></div>
         </div>

--- a/src/routes/dashboard/farm_designer/zone_inventory.js
+++ b/src/routes/dashboard/farm_designer/zone_inventory.js
@@ -29,7 +29,7 @@ export class Zones extends React.Component {
           </div>
         </div>
         <div className="search-box-wrapper">
-          <i class="fa fa-search"></i>
+          <i className="fa fa-search"></i>
           <input className="search" placeholder="Search"/>
           <div className="search-underline"></div>
         </div>

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,8 +9,8 @@ import { Schedules } from './dashboard/schedules/schedules';
 import { FarmDesigner } from './dashboard/farm_designer/farm_designer';
 
 export function getRoutes(store) {
-  console.warn('Errors dealing with ReduxRouterContext Prop/Context types on ' +
-               'the first render are currently expected.');
+  // console.warn('Errors dealing with ReduxRouterContext Prop/Context types on ' +
+  //              'the first render are currently expected.');
 
   return (
     <Route path="/" component={App}>


### PR DESCRIPTION
# Why?

 * Bootstrap doesn't use ES6 modules
 * Bootstrap needs a global `$`
 * Bootstrap was complaining

# What Changed?

 * Globally exported `$` variable.