### PR TITLE
Module build failed: ReferenceError: Promise is not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "style-loader": "^0.13.0",
     "ts-loader": "^0.8.1",
     "webpack": "^1.12.11",
-    "webpack-dev-server": "^1.14.1"
+      "webpack-dev-server": "^1.14.1",
+      "es6-promise": "^3.2.1"
   },
   "dependencies": {
     "axios": "^0.11.0",

--- a/tools/webpack.config.dev.js
+++ b/tools/webpack.config.dev.js
@@ -1,4 +1,5 @@
 var path = require('path');
+require('es6-promise').polyfill();
 
 module.exports = {
   module: {


### PR DESCRIPTION
After the installation, when I run `npm start`, I've got this error. I fixed it via es6-promise.
```bash
Module` build failed: ReferenceError: Promise is not defined
```