### PR TITLE
Added new typings

### DIFF
--- a/src/auth/auth_actions.tsx
+++ b/src/auth/auth_actions.tsx
@@ -16,7 +16,7 @@ export interface AuthResponse {
   token: AuthResponseToken;
 };
 
-export function didLogin(authState: AuthState, dispatch) {
+export function didLogin(authState: AuthState, dispatch:Function) {
     setToken(authState.token);
     dispatch(loginOk(authState));
     dispatch(fetchDevice(authState.token));
@@ -44,7 +44,7 @@ export function onLogin(dispatch: Function) {
   };
 };
 
-export function login(username, password, url) {
+export function login(username:string, password:string, url:string) {
   return dispatch => {
     return requestToken(username, password, url).then(
       onLogin(dispatch),
@@ -76,14 +76,14 @@ export interface LoginOk {
   payload: AuthState;
 };
 
-export function loginOk(token: AuthState) {
+export function loginOk(token: AuthState):Object {
   return {
     type: "LOGIN_OK",
     payload: token
   };
 }
 
-export function register(name, email, password, confirmation, url) {
+export function register(name:string, email:string, password:string, confirmation:string, url:string) {
   return dispatch => {
     let p = requestRegistration(name,
                                 email,
@@ -108,7 +108,7 @@ export function onRegistrationErr(dispatch) {
   };
 }
 
-function requestRegistration(name, email, password, confirmation, url) {
+function requestRegistration(name:string, email:string, password:string, confirmation:string, url:string) {
   let form = {
     user: {
       email: email,
@@ -121,7 +121,7 @@ function requestRegistration(name, email, password, confirmation, url) {
 }
 
 
-function requestToken(email, password, url) {
+function requestToken(email:string, password:string, url:string):JQueryXHR {
   // TODO: Replace with AXIOS.get().
   return $.ajax({
     url: url + "/api/tokens",
@@ -132,7 +132,7 @@ function requestToken(email, password, url) {
 }
 
 // TODO Someday, we will stop using jQuery. This is mostly for legacy support.
-export function setToken(token: string) {
+export function setToken(token: string):void {
   $.ajaxSetup({
     beforeSend: function (xhr) {
       xhr.setRequestHeader("Authorization", token);

--- a/src/auth/auth_reducer.tsx
+++ b/src/auth/auth_reducer.tsx
@@ -33,7 +33,7 @@ let initialState: AuthState = {
   exp: 0,
 };
 
-export function authReducer(state = initialState, action) {
+export function authReducer(state:AuthState = initialState, action) {
   let handler = (action_handlers[action.type] || action_handlers.DEFAULT);
   return handler(state, action);
 }

--- a/src/config/config_reducer.tsx
+++ b/src/config/config_reducer.tsx
@@ -6,7 +6,7 @@ interface ConfigReducerState {
   farmbotApiUrl: string;
 }
 
-function getApiUrl() {
+function getApiUrl():string {
   let host = `//${location.host || "localhost"}`;
   return (host["includes"]("//localhost")) ? "//localhost:3000" : host;
 }

--- a/src/devices/bot_actions.tsx
+++ b/src/devices/bot_actions.tsx
@@ -9,8 +9,8 @@ import { catchMessage, RPCError } from "./message_catcher";
 
 const ON = 1, OFF = 0, DIGITAL = 0;
 
-export function settingToggle(name: string, bot) {
-    return function(dispatch: Function) {
+export function settingToggle(name: string, bot):Function {
+    return function(dispatch: Function):Thenable<void> {
         let currentValue = bot.hardware[name];
         return devices
           .current
@@ -36,7 +36,7 @@ export function settingToggleErr(err) {
 }
 
 
-export function pinToggle(num) {
+export function pinToggle(num):Function {
     return function(dispatch) {
         let currentValue = store.getState().bot.hardware[`pin${num}`];
         let newPinValue = (currentValue === "on") ? OFF : ON;
@@ -91,7 +91,7 @@ export function commitSettingsChanges() {
         .assign(settingsBuffer)
         .value();
     let promise = devices.current.updateCalibration(packet);
-    return function(dispatch) {
+    return function(dispatch):Thenable<void> {
         return promise.then(
             (resp) => dispatch(commitSettingsChangesOk(resp)),
             (err) => dispatch(commitSettingsChangesErr(err)));


### PR DESCRIPTION
Didn't have a ton of time, but added a few in here.  Is there a common interface for the return below?  Seems to be all over but without being typed.  Didn't have time to go looking at the moment.

```
return {
        type: "SAVE_DEVICE_OK",
        payload: resp.data
    };
```

Happy to continue going through when I have some more time, let me know if there are any changes!