### PR TITLE
More specificity for DOM event handlers annotations

### DIFF
--- a/src/regimens/bulk_scheduler/add_button.tsx
+++ b/src/regimens/bulk_scheduler/add_button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 interface AddButtonProps {
   active: boolean;
-  click: Function;
+  click: React.EventHandler<React.FormEvent>;
 }
 
 export function AddButton({active, click}: AddButtonProps) {

--- a/src/regimens/bulk_scheduler/sequence_list.tsx
+++ b/src/regimens/bulk_scheduler/sequence_list.tsx
@@ -17,7 +17,7 @@ export function SequenceList({sequences,
     let selectedValue = current ? sequences.indexOf(_.findWhere(sequences, current)) : -1;
     return <div>
         <label>Sequence</label>
-        <select value={ selectedValue }
+        <select value={ selectedValue.toString() }
                 onChange={ change(dispatch, sequences) }>
             { [NULL_ITEM]
                 .concat(sequences.map((s, i) => { return <SeqListItem s={s} i={i} key={i} />; }))

--- a/src/regimens/bulk_scheduler/week_row.tsx
+++ b/src/regimens/bulk_scheduler/week_row.tsx
@@ -46,7 +46,7 @@ function Day({day, id, dispatch, week, active}: DayProps) {
            className="day"
            onClick={ select(dispatch, day, week) }
            checked={ active }
-           readOnly="1"
+           readOnly={ true }
            />
     <label className="day-label left-most" htmlFor={id}>
       { (week * 7) + day }

--- a/src/regimens/editor/regimen_name_input.tsx
+++ b/src/regimens/editor/regimen_name_input.tsx
@@ -2,15 +2,15 @@ import * as React from "react";
 import { editRegimen } from "../actions";
 import { RegimenProps, Regimen } from "../interfaces";
 
-function write({dispatch, regimen}: RegimenProps): Function {
+function write({dispatch, regimen}: RegimenProps): React.EventHandler<React.FormEvent> {
   if (!regimen) {
     throw new Error("Regimen is required");
   }
-  return (event) => {
+  return (event: React.FormEvent) => {
     regimen = regimen as Regimen; // Almost certainly a bug in TS.
     let action = editRegimen(
       regimen, {
-        name: event.target.value
+        name: event.target["value"]
       }
     );
     dispatch(action);

--- a/src/regimens/list/regimen_list_item.tsx
+++ b/src/regimens/list/regimen_list_item.tsx
@@ -21,5 +21,5 @@ export function RegimenListItem({regimen,
 }
 
 function select(dispatch: Function, index: number) {
-  return (event: Event) => dispatch(selectRegimen(index));
+  return (event: React.MouseEvent) => dispatch(selectRegimen(index));
 }

--- a/src/sequences/execute_block.tsx
+++ b/src/sequences/execute_block.tsx
@@ -34,7 +34,7 @@ function SequenceSelectBox({dispatch,
         return <option value={ seq._id } key={ seq._id } > { seq.name } </option>;
     };
 
-    function change(e: Event) {
+    function change(e: React.FormEvent) {
         let update = {
             command: {
                 value: "0",


### PR DESCRIPTION
Typescript 2.0.0 appears to be catching stuff in React more aggresivly.

Need to sync up with @connorRigby

