### PR TITLE
Regimen saving

### DIFF
--- a/src/regimens/actions.ts
+++ b/src/regimens/actions.ts
@@ -26,7 +26,8 @@ export function saveRegimen(regimen: Regimen, baseUrl: string, token: string) {
       payload: regimen
     });
 
-    return Axios.post<Regimen>(baseUrl + REGIMEN_URL,
+    const action = regimen.id ? Axios.put : Axios.post 
+    return action<Regimen>(baseUrl + REGIMEN_URL,
       regimenSerializer(regimen))
       .then(resp => dispatch(saveRegimenOk(resp.data)))
       .catch(err => dispatch(saveRegimenErr(err)));

--- a/src/regimens/bulk_scheduler/actions.ts
+++ b/src/regimens/bulk_scheduler/actions.ts
@@ -1,7 +1,7 @@
 import { warning } from "../../logger";
 import { BulkSchedulerOutput,
     BulkSchedulerState } from "./interfaces";
-// import { RegimenItem } from "../interfaces";
+import { RegimenItem } from "../interfaces";
 import { ReduxAction } from "../../interfaces";
 import { Sequence } from "../../sequences/interfaces";
 
@@ -90,6 +90,7 @@ export function commitBulkEditor(state: BulkSchedulerState):
 
     let keys = ["day1", "day2", "day3", "day4", "day5", "day6", "day7"];
 
+    // TODO: This function needs to be in a seperate file and have unit tests.
     const regimenItems = state
         .form
         .weeks
@@ -115,9 +116,15 @@ export function commitBulkEditor(state: BulkSchedulerState):
         // sort (duh)
         .sort()
         // Transform the sorted array of values into a regimenItem[] array.
-        .map((timeOffset) => {
-          let sequence = _.cloneDeep(state.sequence);
-          return { timeOffset, sequence };
+        .map<RegimenItem>((time_offset) => {
+            if (state.sequence) {
+                let sequence = state.sequence && _.cloneDeep<Sequence>(state.sequence);
+                return { time_offset, sequence };
+            } else {
+                // Typescript type check acts funny as of TSC 2.0
+                // Maybe we can delete this some day?
+                throw new Error("Opps");
+            };
         });
 
     return {

--- a/src/regimens/editor/regimen_item_list.tsx
+++ b/src/regimens/editor/regimen_item_list.tsx
@@ -11,7 +11,7 @@ interface RegimenItemListProps {
 
 export function RegimenItemList({ items, dispatch }: RegimenItemListProps) {
   let groups = _.groupBy<RegimenItem>(items, function(item: RegimenItem) {
-    return Math.round(duration(item.timeOffset).asDays());
+    return Math.round(duration(item.time_offset).asDays());
   });
 
   let list = _.map(groups, function(innerItems: RegimenItem[], day: string) {
@@ -39,12 +39,11 @@ interface RegimenItemStepProps {
   dispatch: Function;
 }
 function RegimenItemStep({ item, dispatch }: RegimenItemStepProps) {
-  let d = duration(item.timeOffset);
+  let d = duration(item.time_offset);
   let time = moment({
     hour: d.hours(),
     minute: d.minutes()
   }).format("h:mm a");
-
   return <div className="regimen-event">
   <span className="regimen-event-title"> { item.sequence.name } </span>
   <span className="regimen-event-time"> { time } </span>
@@ -57,7 +56,6 @@ interface RegimenItemDayGroupProps {
     day: string;
     items: RegimenItem[];
     dispatch: Function;
-    // key: string|number; // Props can be deleted later. Bug hunting atm.
 }
 
 function RegimenItemDayGroup({ day,

--- a/src/regimens/interfaces.ts
+++ b/src/regimens/interfaces.ts
@@ -31,7 +31,7 @@ export interface Regimen {
 export interface RegimenItem {
     sequence: Sequence;
     /** Time (in milliseconds) to wait before executing the sequence */
-    timeOffset: number;
+    time_offset: number;
 };
 
 /** How Regimen state is stored in the application. Used by Regimen reducer mostly */

--- a/src/regimens/reducer.ts
+++ b/src/regimens/reducer.ts
@@ -75,15 +75,9 @@ let action_handlers: RegimensActionHandler = {
         return s;
     },
     FETCH_REGIMENS_OK: function(s: RegimensState,
-        a: ReduxAction<RegimenItem>){
+        a: ReduxAction<Regimen[]>){
       const nextState = _.cloneDeep<RegimensState>(s);
-      console.warn(`
-      Stopped here. See regimenItemDeserializer to continue.
-       AMS is broke on the API.
-       Need to fix it so that regimenItems include a nested "Sequence". Otherwise
-       will be a lot of work with caching. SEE regimen_serializer.rb.
-      `);
-      debugger;
+      nextState.all = _.cloneDeep<Regimen[]>(a.payload);
       return nextState;
     }
 };

--- a/src/regimens/serializers.ts
+++ b/src/regimens/serializers.ts
@@ -31,7 +31,7 @@ export function regimenSerializer(input: Regimen): ApiRegimen {
         .map<ApiRegimenItem>(function wow(r) {
             if (r && r.sequence && r.sequence.id) {
                 return {
-                    time_offset: r.timeOffset,
+                    time_offset: r.time_offset,
                     sequence_id: r.sequence.id
                 };
             } else {

--- a/src/regimens/temporary_stubs.tsx
+++ b/src/regimens/temporary_stubs.tsx
@@ -23,7 +23,7 @@ let firstItem: Regimen = {
                 ],
                 dirty: false
             },
-            timeOffset: THIRTY_SIX_HOURS
+            time_offset: THIRTY_SIX_HOURS
         },
         {
             sequence: {
@@ -40,7 +40,7 @@ let firstItem: Regimen = {
                 ],
                 dirty: false
             },
-            timeOffset: THIRTY_SIX_HOURS * 2
+            time_offset: THIRTY_SIX_HOURS * 2
         },
     ]
 };


### PR DESCRIPTION
# What's New?

 * Store regimens in the API so that they're there when you come back to the editor.
 * Fix a subtle bug relating to Rails naming vs. frontend naming that caused really quiet runtime errors.
 * Other stuff that I will discuss in the API repo.

# What's Next?

 * Better error messages for deletions
 * Set `dirty` to true when adding a list of regimen items from the bulk editor.
 * Validate uniqueness of names in Regimen editor.
 * (probably) backend updates to Regimens.
