### PR TITLE
Extract css for prod builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@ npm-debug.log
 app-resources/*bundle.js*
 app-resources/bundle.js
 app-resources/bundle.js.map
+app-resources/*styles.css*
+app-resources/styles.css
+app-resources/styles.css.map
 app/*bundle.js*

--- a/app/index.html
+++ b/app/index.html
@@ -9,6 +9,7 @@
 	<script src="maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"> </script>
 	<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 	<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+	<link rel="stylesheet" href="/app-resources/styles.css">
 	<script type="text/javascript" src="/app-resources/bundle.js"></script>
 </body>
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^0.14.0",
     "css-loader": "^0.25.0",
     "enzyme": "^2.4.1",
+    "extract-text-webpack-plugin": "^1.0.1",
     "farmbot": "2.1.4",
     "i18next": "^3.4.3",
     "jasmine-core": "^2.4.1",

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,4 @@
-require("!style!css!sass!./css/index.scss");
+require("./css/index.scss");
 import * as React from "react";
 
 import {

--- a/tools/webpack.config.base.js
+++ b/tools/webpack.config.base.js
@@ -3,7 +3,7 @@ var path = require('path')
   , execSync = require('child_process').execSync
   , webpack = require('webpack');
 
-exec("rm app-resources/*bundle.js*"); // Clean previous stuff.
+exec("rm app-resources/*bundle.js* app-resources/*styles.css*"); // Clean previous stuff.
 
 var revisionPlugin = new webpack.DefinePlugin({
   'process.env.REVISION': JSON.stringify(execSync('git log --pretty=format:"%h%n%ad%n%f" -1').toString()),

--- a/tools/webpack.config.dev.js
+++ b/tools/webpack.config.dev.js
@@ -4,7 +4,16 @@ var exec = require("child_process").execSync;
 
 c = function () {
   var conf = generateConfig();
+  
+  conf
+    .module
+    .loaders
+    .push({
+      test: /\.scss$/, loader: 'style-loader!css-loader!sass-loader'
+    });
+
   conf.devtool = 'source-map';
+
   conf
     .plugins
     .push(new webpack.DefinePlugin({

--- a/tools/webpack.config.prd.js
+++ b/tools/webpack.config.prd.js
@@ -2,9 +2,17 @@ var webpack = require('webpack');
 var generateConfig = require("./webpack.config.base");
 var exec = require("child_process").execSync;
 var path = require("path");
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 c = function () {
   var conf = generateConfig();
+
+  conf
+    .module
+    .loaders
+    .push({
+      test: /\.scss$/, loader: ExtractTextPlugin.extract('style', 'css-loader!sass-loader')
+    });
 
   conf.devtool = 'source-map';
 
@@ -23,8 +31,10 @@ c = function () {
       compressor: { warnings: false },
     }));
 
+  conf
+    .plugins
+    .push(new ExtractTextPlugin("./styles.css"));
+
   return conf;
 }
 module.exports = c();
-
-


### PR DESCRIPTION
- css sourcemapping
- css requested in parallel
- css cached separate
- faster runtime (less code and DOM operations)

Only bummer is obviously the console will throw an error regarding /app-resources/styles.css from index.html for development since it will be programmatically inserted, but is anyone opposed to using html-webpack-plugin to avoid that case?
