### PR TITLE
add title to direction buttons indicating axis responsibility

### DIFF
--- a/src/controls/direction_button.tsx
+++ b/src/controls/direction_button.tsx
@@ -17,7 +17,14 @@ export class DirectionButton extends React.Component<DirectionButtonProps, {}> {
   render() {
     let { direction } = this.props;
     let classes = `fa fa-2x arrow-button radius fa-arrow-${direction}`;
-    return <button onClick={this.sendCommand} className={classes}>
-    </button>;
+    let title = `move ${this.props.axis} axis`;
+    return (
+      <button
+        onClick={this.sendCommand}
+        className={classes}
+        title={title}
+        >
+      </button>
+    );
   }
 }


### PR DESCRIPTION
Did not find the control's arrow buttons very intuitive when I tried it earlier for the first time...

Therefore I added title tags to the buttons, showing axis info upon hovering.